### PR TITLE
Set CIRCLE_REPOSITORY_URL as default

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Note: we deliberately DO NOT have the standard "- checkout" step, as this orb replace it
       - fast-checkout/get:
-          repo-uri: "https://github.com/issmirnov/fast-checkout-orb.git"
+          repo-uri: "${CIRCLE_REPOSITORY_URL}"
           branch: "main"
           sparse-paths: "src/ README.md"
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Note: we deliberately DO NOT have the standard "- checkout" step, as this orb replace it
       - fast-checkout/get:
-          repo-uri: "${CIRCLE_REPOSITORY_URL}"
+          # repo-uri: "${CIRCLE_REPOSITORY_URL}" # DO NOT SUBMIT - unset default and see if it still works
           branch: "main"
           sparse-paths: "src/ README.md"
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       # Note: we deliberately DO NOT have the standard "- checkout" step, as this orb replace it
       - fast-checkout/get:
-          # repo-uri: "${CIRCLE_REPOSITORY_URL}" # DO NOT SUBMIT - unset default and see if it still works
           branch: "main"
           sparse-paths: "src/ README.md"
       - run:

--- a/src/commands/get.yml
+++ b/src/commands/get.yml
@@ -7,6 +7,7 @@ parameters:
     description: "Name of branch to check out"
   repo-uri:
     type: string
+    default: "${CIRCLE_REPOSITORY_URL}"
     description: "Valid git clone URI. Can be SSH or HTTPS. You can use $CIRCLE_REPOSITORY_URL as well."
   sparse-paths:
     type: string


### PR DESCRIPTION
Previously, we had users provide the repo-uri in all cases. Since circleCI env var expansion works as hoped, we can set this as a default value and the step will work as intended.