### PR TITLE
Support custom working-directory

### DIFF
--- a/src/commands/get.yml
+++ b/src/commands/get.yml
@@ -25,8 +25,8 @@ steps:
       name: Fast Checkout
       command: |
         mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> ~/project
-        cd ~/project
+        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> << pipeline.parameters.workingdir >>
+        cd << pipeline.parameters.workingdir >>
         git sparse-checkout init --cone
         git sparse-checkout set <<parameters.sparse-paths>>
         git read-tree -mu HEAD

--- a/src/commands/get.yml
+++ b/src/commands/get.yml
@@ -29,8 +29,8 @@ steps:
       name: Fast Checkout
       command: |
         mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> << pipeline.parameters.working-directory >>
-        cd << pipeline.parameters.working-directory >>
+        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> << parameters.working-directory >>
+        cd << parameters.working-directory >>
         git sparse-checkout init --cone
         git sparse-checkout set <<parameters.sparse-paths>>
         git read-tree -mu HEAD

--- a/src/commands/get.yml
+++ b/src/commands/get.yml
@@ -12,6 +12,10 @@ parameters:
   sparse-paths:
     type: string
     description: "List of paths from the root of the repo that will be checked out."
+  working-directory:
+    type: string
+    default: "~/project"
+    description: "Directory to clone the repo into. If you set working_directory on your job, set this param here as well."
 
 steps:
   # - run:
@@ -25,8 +29,8 @@ steps:
       name: Fast Checkout
       command: |
         mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> << pipeline.parameters.workingdir >>
-        cd << pipeline.parameters.workingdir >>
+        git clone --no-checkout --filter=blob:none <<parameters.repo-uri>> << pipeline.parameters.working-directory >>
+        cd << pipeline.parameters.working-directory >>
         git sparse-checkout init --cone
         git sparse-checkout set <<parameters.sparse-paths>>
         git read-tree -mu HEAD


### PR DESCRIPTION
Previously, the orb hardcoded the clone location to ~/project. If someone wants to use /mnt/ramdisk or some other dir instead, this would break their build. We now add the parameter with a sane default.

As best as I can tell, CircleCI does not natively expose the `working_directory` value to the pipeline params.